### PR TITLE
A new system property jsii.node takes precedence over the environment…

### DIFF
--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -77,12 +77,17 @@ public final class JsiiRuntime {
     @Nullable
     private final String customRuntime;
 
-    /** The value of the JSII_NODE environment variable */
+    /** The value of the JSII_NODE property or environment variable */
     @Nullable
     private final String customNode;
 
     public JsiiRuntime() {
-        this(System.getenv("JSII_RUNTIME"), System.getenv("JSII_NODE"));
+        // Try system property first, fall back to environment variable
+        String nodeValue = System.getProperty("jsii.node");
+        if (nodeValue == null) {
+            nodeValue = System.getenv("JSII_NODE");
+        }
+        this(System.getenv("JSII_RUNTIME"), nodeValue);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
1. Introduces a new system property jsii.node that takes precedence over the environment variable
2. Maintains backward compatibility by falling back to the environment variable if the property is not set
3. Uses Java naming conventions for the property name (jsii.node instead of JSII_NODE)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
